### PR TITLE
Slide: Use Season names

### DIFF
--- a/720p/View_Slide_51.xml
+++ b/720p/View_Slide_51.xml
@@ -70,6 +70,7 @@
 						<include>SlideViewFocusAnimation</include>
 						<include content="HomeWidgetsTitleLabel">
 							<param name="width" value="935"/>
+							<param name="label" value="$VAR[ListItem_LabelVar]"/>
 							<param name="visible" value="!ListItem.IsParentFolder"/>
 							<param name="animation_end" value="0,-245"/>
 							<param name="animation_condition" value="Control.HasFocus(100)"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="skin.bello.10" version="10.0.1" name="Bello 10" provider-name="Nessus">
+<addon id="skin.bello.10" version="10.0.2" name="Bello 10" provider-name="Nessus">
   <requires>
 		<import addon="xbmc.gui" version="5.17.0"/>
 		<import addon="script.skinshortcuts" version="2.0.3"/>


### PR DESCRIPTION
I noticed a while ago that the Slide view was only showing the Show's name for each Season. First thought it was a limitation of Jellyfin's Kodi integration, and it wasn't until I tried a couple of the other views that I realised the Season Names are in fact available :sweat_smile: 

After digging through the skin code a bit, I found that this view wasn't setting a label like every other view does (including its music view). Patched it in, and it works as expected.

Before:
<img width="2560" height="1440" alt="before" src="https://github.com/user-attachments/assets/260c6030-e34b-4def-bd6b-14f2ae4b7e51" />

After:
<img width="2560" height="1440" alt="after" src="https://github.com/user-attachments/assets/1635df49-7329-4f7f-beb4-7990223986ec" />

Ignore the wrong/identical posters, that's *not* an issue with the skin but with my testing library.